### PR TITLE
Extensions with spaces and export path parameter

### DIFF
--- a/ExportExtensions/ExportExtensions.vsct
+++ b/ExportExtensions/ExportExtensions.vsct
@@ -69,6 +69,27 @@
           <ButtonText>Export Extensions</ButtonText>
         </Strings>
       </Button>
+
+
+      <Button guid="guidVSExtensionsImportExportCmdSet" id="cmdidExportExtensionListTo" priority="0x9010" type="Button">
+        <Icon guid="guidImages" id="exportExt" />
+        <CommandFlag>AllowParams</CommandFlag>
+        <Strings>
+          <LocCanonicalName>Tools.ExportExtensionsTo</LocCanonicalName>
+          <ButtonText>Export Extensions To...</ButtonText>
+        </Strings>
+      </Button>
+
+
+      <Button guid="guidVSExtensionsImportExportCmdSet" id="cmdidExportExtensionListToAndExit" priority="0x9010" type="Button">
+        <Icon guid="guidImages" id="exportExt" />
+        <CommandFlag>AllowParams</CommandFlag>
+        <Strings>
+          <LocCanonicalName>Tools.ExportExtensionsToAndExit</LocCanonicalName>
+          <ButtonText>Export Extensions To and Exit...</ButtonText>
+        </Strings>
+      </Button>
+      
     </Buttons>
    
     <!--The bitmaps section is used to define the bitmaps that are used for the commands.-->
@@ -98,6 +119,10 @@
       <IDSymbol name="MyMenuGroup" value="0x1020" />
       <IDSymbol name="cmdidExportExtensionList" value="0x0100" />
       <IDSymbol name="cmdidImportExtensionList" value="0x0101" />
+      <IDSymbol name="cmdidExportExtensionListTo" value="0x0200" />
+      <IDSymbol name="cmdidImportExtensionListTo" value="0x0201" />
+      <IDSymbol name="cmdidExportExtensionListToAndExit" value="0x0300" />
+      <IDSymbol name="cmdidImportExtensionListToAndExit" value="0x0301" />
     </GuidSymbol>
     
     

--- a/ExportExtensions/ExportExtensionsPackage.cs
+++ b/ExportExtensions/ExportExtensionsPackage.cs
@@ -31,6 +31,14 @@ namespace TTRider.ExportExtensions
             if (null != mcs)
             {
                 mcs.AddCommand(new MenuCommand(this.manager.ExportExtensions, new CommandID(GuidList.guidVSExtensionsImportExportCmdSet, (int)PkgCmdIDList.cmdidExportExtensionList)));
+                
+                OleMenuCommand menuItem2 = new OleMenuCommand(this.manager.ExportExtensionsTo, new CommandID(GuidList.guidVSExtensionsImportExportCmdSet, (int)PkgCmdIDList.cmdidExportExtensionListTo));
+                menuItem2.ParametersDescription = "p";
+                mcs.AddCommand(menuItem2);
+
+                OleMenuCommand menuItem3 = new OleMenuCommand(this.manager.ExportExtensionsToAndExit, new CommandID(GuidList.guidVSExtensionsImportExportCmdSet, (int)PkgCmdIDList.cmdidExportExtensionListToAndExit));
+                menuItem3.ParametersDescription = "p";
+                mcs.AddCommand(menuItem3);
             }
         }
         #endregion

--- a/ExportExtensions/ExtensionInfo.cs
+++ b/ExportExtensions/ExtensionInfo.cs
@@ -8,5 +8,6 @@
         public string Identifier { get; set; }
         public string DownloadUrl { get; set; }
         public string DownloadAs { get; set; }
+        public Microsoft.VisualStudio.ExtensionManager.EnabledState State { get; set; }
     }
 }

--- a/ExportExtensions/Manager.cs
+++ b/ExportExtensions/Manager.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.ServiceModel;
 using System.Text;
 using Microsoft.VisualStudio.ExtensionManager;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using TTRider.ExportExtensions.ExtensionService;
 
@@ -15,9 +16,15 @@ namespace TTRider.ExportExtensions
     {
         private readonly IVsExtensionManager extensionManager;
         private readonly IVsThreadedWaitDialogFactory dialogFactory;
+        private IVsOutputWindowPane generalPane;
 
         public Manager(IVsExtensionManager extensionManager, IVsThreadedWaitDialogFactory dialogFactory)
         {
+            IVsOutputWindow outWindow = Microsoft.VisualStudio.Shell.Package.GetGlobalService(typeof(SVsOutputWindow)) as IVsOutputWindow;
+            Guid generalPaneGuid = Microsoft.VisualStudio.VSConstants.GUID_OutWindowDebugPane;
+            outWindow.GetPane(ref generalPaneGuid, out generalPane);
+            generalPane.Activate(); // Brings this pane into view
+
             this.extensionManager = extensionManager;
             this.dialogFactory = dialogFactory;
         }
@@ -55,7 +62,8 @@ namespace TTRider.ExportExtensions
                     Name = ext.Header.Name,
                     Description = ext.Header.Description,
                     Author = ext.Header.Author,
-                    Identifier = ext.Header.Identifier
+                    Identifier = ext.Header.Identifier,
+                    State = ext.State
                 });
         }
 
@@ -94,6 +102,12 @@ namespace TTRider.ExportExtensions
         ExtensionInfo GetExtensionDownloadUrl(ExtensionInfo ex)
         {
             var release = DownloadExtensionDetails(ex);
+            //generalPane.OutputString(ex.Name + "\t" +
+            //    ((release == null) ? "null" : "not null") + "\t" +
+            //    //ex.Description + "\t" +
+            //    ex.Author + "\t" +
+            //    ex.Identifier + "\t" +
+            //    ex.State.ToString() + "\n");
             string url = null;
             if (release != null && !release.Project.Metadata.TryGetValue("DownloadUrl", out url))
             {
@@ -133,8 +147,25 @@ namespace TTRider.ExportExtensions
 
             try
             {
+                //var extensions = this.GetInstalledExtensions();
+
+
+                //var count = 0;
+                //generalPane.OutputString("Short list:\n");
+                //foreach (var extension in extensions)
+                //{
+                //    count++;
+                //    generalPane.OutputString(extension.Name + "\t" +
+                //        //extension.Description + "\t" +
+                //        extension.Author + "\t" +
+                //        extension.Identifier + "\t" +
+                //        extension.State.ToString() + "\n");
+                //}
+                //generalPane.OutputString("Total: " + count + "\n\n");
+                //generalPane.Activate(); // Brings this pane into view
+
                 var extensions = this.GetInstalledExtensions()
-                    .Select(ext =>
+					.Select(ext =>
                     {
                         if (dialog != null)
                         {

--- a/ExportExtensions/Manager.cs
+++ b/ExportExtensions/Manager.cs
@@ -29,6 +29,23 @@ namespace TTRider.ExportExtensions
             this.dialogFactory = dialogFactory;
         }
 
+        private void IDEShutDown(EnvDTE.DTE dte)
+        {
+            if (dte != null)
+            {
+                // Add code to dispose of custom objects, save files, 
+                // and perform any clean-up tasks.
+
+                // Stop external process debugging.
+                if (dte.Mode == EnvDTE.vsIDEMode.vsIDEModeDebug)
+                {
+                    dte.Debugger.Stop(true);
+                }
+
+                // Close the DTE object.
+                dte.Quit();
+            }
+        }
 
         internal void ExportExtensions(object sender, EventArgs e)
         {
@@ -51,6 +68,66 @@ namespace TTRider.ExportExtensions
             }
 
             DoExport(ofd.FileName);
+        }
+
+        internal void ExportExtensionsTo(object sender, EventArgs e)
+        {
+            var args = (OleMenuCmdEventArgs)e;
+            if (args.InValue != null && args.InValue.ToString() != "")
+            {
+                var s = args.InValue.ToString();
+                if ((s[0] == '\"') && (s[s.Length - 1] == '\"'))
+                {
+                    s = args.InValue.ToString().Replace("\"", "");
+                }
+                else if ((s[0] == '\'') && (s[s.Length - 1] == '\''))
+                {
+                    s = args.InValue.ToString().Replace("\'", "");
+                }
+                var fileInfo = new FileInfo(s);
+                if ((fileInfo.Directory.ToString() != (new FileInfo("Invalid").Directory.ToString())) &&
+                    (fileInfo.Extension == ".cmd"))
+                {
+                    DoExport(s);
+                }
+
+                return;
+            } else
+            {
+                generalPane.OutputString("No path specified for export.\n");
+                generalPane.Activate();
+            }
+        }
+
+        internal void ExportExtensionsToAndExit(object sender, EventArgs e)
+        {
+            var args = (OleMenuCmdEventArgs)e;
+            if (args.InValue != null && args.InValue.ToString() != "")
+            {
+                var s = args.InValue.ToString();
+                if ((s[0] == '\"') && (s[s.Length - 1] == '\"'))
+                {
+                    s = args.InValue.ToString().Replace("\"", "");
+                }
+                else if ((s[0] == '\'') && (s[s.Length - 1] == '\''))
+                {
+                    s = args.InValue.ToString().Replace("\'", "");
+                }
+                var fileInfo = new FileInfo(s);
+                if ((fileInfo.Directory.ToString() != (new FileInfo("Invalid").Directory.ToString())) &&
+                    (fileInfo.Extension == ".cmd"))
+                {
+                    DoExport(s);
+                    IDEShutDown(Microsoft.VisualStudio.Shell.Package.GetGlobalService(typeof(Microsoft.VisualStu‌​dio.Shell.Interop.SD‌​TE)) as EnvDTE.DTE);
+                }
+
+                return;
+            }
+            else
+            {
+                generalPane.OutputString("No path specified for export.\n");
+                generalPane.Activate();
+            }
         }
 
         private IEnumerable<ExtensionInfo> GetInstalledExtensions()

--- a/ExportExtensions/PkgCmdID.cs
+++ b/ExportExtensions/PkgCmdID.cs
@@ -6,5 +6,7 @@ namespace TTRider.ExportExtensions
     static class PkgCmdIDList
     {
         public const uint cmdidExportExtensionList = 0x100;
+        public const uint cmdidExportExtensionListTo = 0x200;
+        public const uint cmdidExportExtensionListToAndExit = 0x300;
     };
 }

--- a/ExportExtensions/source.extension.vsixmanifest
+++ b/ExportExtensions/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="09F4D959-981C-40CF-AD72-F692910651F1" Version="1.1" Language="en-US" Publisher="TTRider, L.L.C." />
+    <Identity Id="09F4D959-981C-40CF-AD72-F692910651F1" Version="1.2" Language="en-US" Publisher="TTRider, L.L.C." />
     <DisplayName>Export Extensions 2015.1</DisplayName>
     <Description>Provides an ability to Import/Export the list of Visual Studio extensions</Description>
     <Tags>Visual Studio;Extensions</Tags>

--- a/ExportExtensions/templates/ps.template
+++ b/ExportExtensions/templates/ps.template
@@ -13,7 +13,7 @@ wget -Uri $url -OutFile $as;
 "Installing '$name' by '$author'"; 
 if ([System.IO.Path]::GetExtension($as) -eq ".vsix" -and $vsxcmd -ne $null)
 {
-    Start-Process $vsxcmd -ArgumentList "/q $as"  -Wait;
+    Start-Process $vsxcmd -ArgumentList "/q `"$as`""  -Wait;
 }
 else
 {

--- a/ExportExtensions2013/ExportExtensions/templates/ps.template
+++ b/ExportExtensions2013/ExportExtensions/templates/ps.template
@@ -13,7 +13,7 @@ wget -Uri $url -OutFile $as;
 "Installing '$name' by '$author'"; 
 if ([System.IO.Path]::GetExtension($as) -eq ".vsix" -and $vsxcmd -ne $null)
 {
-    Start-Process $vsxcmd -ArgumentList "/q $as"  -Wait;
+    Start-Process $vsxcmd -ArgumentList "/q `"$as`""  -Wait;
 }
 else
 {


### PR DESCRIPTION
Add following functionality:
1. Able to deal with .vsix extensions that have spaces in the name, e.g. "Multi Edit Mode v1.8.15.vsix"
2. Extension can be called from the command window, providing the path to the exported .cmd file. e.g.
`Tools.ExportExtensionsTo "C:\Users\alband\Documents\Extensions.cmd"`
3. Extension can be called such that it closes Visual Studio after the export is finished. e.g.
`Tools.ExportExtensionsToAndExit "C:\Users\alband\Documents\Extensions.cmd"`

Points 2 and 3 allow this extension to be used in part of a scheduled backup routine. For example, in a batch file:
`"C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\devenv.exe" /Command "Tools.ExportExtensionsToAndExit 'C:\Users\alband\BackupStuff\SetupVisualStudioExtensions.cmd'"`
The above line, when used in a .bat file, will open a Visual Studio instance, export the extensions, then close the Visual Studio instance.

If the provided parameter is invalid (i.e. the containing folder doesn't exist) the extension just returns and outputs a message to the output window.

I've only coded for VS2015 as that's all I have. I'm sure it could be coded better as I'm new to writing extensions and C#.